### PR TITLE
Metal and stars compatibility

### DIFF
--- a/lignumis/info.json
+++ b/lignumis/info.json
@@ -18,6 +18,7 @@
         "Wood-Walls >= 1.2.0",
         "?hot-metals >= 1.1.0",
         "?wood-military >= 2.3.3",
+        "?metal-and-stars",
         "!apm_power_ldinc",
         "!alien-biomes",
         "!wood-logistics",

--- a/lignumis/prototypes/compatibility/data.lua
+++ b/lignumis/prototypes/compatibility/data.lua
@@ -1,2 +1,3 @@
 require("hot-metals")
 require("wood-military")
+require("metal-and-stars")

--- a/lignumis/prototypes/compatibility/metal-and-stars.lua
+++ b/lignumis/prototypes/compatibility/metal-and-stars.lua
@@ -4,3 +4,5 @@ end
 
 data.raw.recipe["gold-plate"].enabled = true
 data.raw.recipe["gold-cable"].enabled = true
+
+data.raw.item["gold-plate"].icon = "__lignumis__/graphics/icons/gold-plate.png"

--- a/lignumis/prototypes/compatibility/metal-and-stars.lua
+++ b/lignumis/prototypes/compatibility/metal-and-stars.lua
@@ -1,0 +1,6 @@
+if not mods["metal-and-stars"] then
+	return
+end
+
+data.raw.recipe["gold-plate"].enabled = true
+data.raw.recipe["gold-cable"].enabled = true

--- a/lignumis/prototypes/integrations/vanilla-updates.lua
+++ b/lignumis/prototypes/integrations/vanilla-updates.lua
@@ -5,7 +5,7 @@ for _, technology in pairs(data.raw.technology) do
     if technology.unit and technology.unit.ingredients and not table.contains(Lignumis.science_blacklist, technology.name) then
         local ingredients = technology.unit.ingredients
         local noMatches = table.filter(ingredients, function(ingredient)
-            return table.contains({ "wood-science-pack", "steam-science-pack" }, ingredient[1])
+            return table.contains({ "wood-science-pack", "steam-science-pack", "nanite-science-pack", "quantum-science-pack", "ring-science-pack" }, ingredient[1])
         end)
         local yesMatches = table.filter(ingredients, function(ingredient)
             return table.contains({ "utility-science-pack", "production-science-pack", "space-science-pack" }, ingredient[1])


### PR DESCRIPTION
Compatibility for [Metal and Stars](https://mods.factorio.com/mod/metal-and-stars)
- Fixes a startup crash due to the wood & steam research packs being added to metal and stars techs.
(https://mods.factorio.com/mod/metal-and-stars/discussion/678f7dae0b011b77fe445ba6)
- Fixes gold being a later game resource in metal and stars locked behind research. Since it doesn't appear to be a major balance concern I just re-enabled the affected recipes.

It's possible you'd prefer to fix these in a slightly different way, especially the tech pack exclusions, but at least this works as a starting point.